### PR TITLE
Add macos-latest to workflow actions

### DIFF
--- a/.github/workflows/remote-integ-tests-workflow.yml
+++ b/.github/workflows/remote-integ-tests-workflow.yml
@@ -19,7 +19,7 @@ jobs:
     name: Run integ tests without security
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         java: [11]
         include:
           - os: windows-latest

--- a/public/pages/DetectorResults/containers/AnomalyResults.tsx
+++ b/public/pages/DetectorResults/containers/AnomalyResults.tsx
@@ -66,6 +66,7 @@ import { detectorIsSample } from '../../Overview/utils/helpers';
 import { SampleIndexDetailsCallout } from '../../Overview/components/SampleIndexDetailsCallout/SampleIndexDetailsCallout';
 import { CoreStart } from '../../../../../../src/core/public';
 import { CoreServicesContext } from '../../../components/CoreServices/CoreServices';
+import { DEFAULT_SHINGLE_SIZE } from '../../../utils/constants';
 
 interface AnomalyResultsProps extends RouteComponentProps {
   detectorId: string;
@@ -313,7 +314,8 @@ export function AnomalyResults(props: AnomalyResultsProps) {
               <p>
                 Attempting to initialize the detector with historical data.
                 This initializing process takes approximately 1 minute if
-                 you have data in each of the last 40 consecutive intervals.
+                you have data in each of the last{' '}
+                {32+get(detector, 'shingleSize', DEFAULT_SHINGLE_SIZE)}{' '} consecutive intervals.
               </p>
             </EuiText>
           </EuiFlexGroup>


### PR DESCRIPTION
Signed-off-by: Michael Froh <froh@amazon.com>

### Description
This PR was generated by a script.

In order to get a rough idea of the effort required to build a MacOS
distribution of OpenSearch, a good first step is enabling MacOS builds
wherever we build for Windows.

Rather than opening an issue in every repo asking maintainers to add
`macos-latest` to their `matrix.os`, I've decided to try automating it
to see what works and what breaks.

### Next steps
If you're reviewing this PR, you may be wondering what to do with it.

**Did the checks pass?** Great! You can probably safely merge the PR 
and let your build workflows run on MacOS.

**Did the checks fail?** You can discard this PR or ignore it. @msfroh
will track the failure and document it. If many PRs see check failures
with the same root cause, we may try to address that and repeat this 
experiment.
